### PR TITLE
Actualizar OpenAPI para funcionar con Spring Boot 3, deprecar y actualizar endpoint de actualizar saludo default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,13 +26,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-hateoas")
     implementation("org.springframework.boot:spring-boot-starter-data-rest")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.springframework.boot:spring-boot-starter-web-services")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.2") //
-    implementation("org.springdoc:springdoc-openapi-ui:1.6.14") //
+    implementation("org.springdoc:springdoc-openapi-starter-common:2.2.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
     implementation("org.springframework.boot:spring-boot-devtools")
 
     // testing

--- a/src/main/kotlin/org/uqbar/egsaludospringkotlin/controller/SaludoController.kt
+++ b/src/main/kotlin/org/uqbar/egsaludospringkotlin/controller/SaludoController.kt
@@ -34,8 +34,8 @@ class SaludoController {
 
 class Saludador {
     companion object {
-        var ultimoId = 1
-        val PERSONA_PROHIBIDA = "dodain"
+        private var ultimoId = 1
+        const val PERSONA_PROHIBIDA = "dodain"
     }
 
     private var saludoDefault = "Hola mundo!"

--- a/src/main/kotlin/org/uqbar/egsaludospringkotlin/controller/SaludoController.kt
+++ b/src/main/kotlin/org/uqbar/egsaludospringkotlin/controller/SaludoController.kt
@@ -2,6 +2,7 @@ package org.uqbar.egsaludospringkotlin.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDateTime
 import javax.annotation.processing.Generated
@@ -19,7 +20,11 @@ class SaludoController {
     fun saludarPersonalizadamente(@PathVariable persona: String) =
         this.saludador.buildSaludoCustom("Hola $persona!")
 
-    @PutMapping("/saludoDefault")
+    @PutMapping(
+        path = ["/saludoDefault"],
+        consumes = [MediaType.TEXT_PLAIN_VALUE],
+        produces = [MediaType.TEXT_PLAIN_VALUE]
+    )
     @Operation(summary = "Actualiza el valor del nuevo saludo por defecto")
     fun actualizarSaludoPersonalizado(@RequestBody nuevoSaludo: String): String {
         this.saludador.cambiarSaludoDefault(nuevoSaludo)

--- a/src/test/kotlin/org/uqbar/egsaludospringkotlin/SaludoApplicationTests.kt
+++ b/src/test/kotlin/org/uqbar/egsaludospringkotlin/SaludoApplicationTests.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.json.AutoConfigureJsonTesters
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
@@ -21,6 +22,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 // ...que genera un contexto por cada test, utilizamos la anotación @AfterEach
 class SaludoApplicationTests(@Autowired val mockMvc: MockMvc) {
 
+	private fun plainTextPut(url: String) = put(url).contentType(MediaType.TEXT_PLAIN)
+
 	@Test
 	fun `el saludo default es el que tiene el saludador`() {
 		mockMvc.perform(get("/saludoDefault"))
@@ -30,7 +33,7 @@ class SaludoApplicationTests(@Autowired val mockMvc: MockMvc) {
 
 	@Test
 	fun `actualizar el saludo a un valor incorrecto produce un error de usuario`() {
-		val message = mockMvc.perform(put("/saludoDefault").content("dodain"))
+		val message = mockMvc.perform(plainTextPut("/saludoDefault").content("dodain"))
 			.andExpect(status().isBadRequest)
 			.andReturn().resolvedException?.message
 		assertEquals("No se puede saludar a dodain", message)
@@ -39,7 +42,7 @@ class SaludoApplicationTests(@Autowired val mockMvc: MockMvc) {
 	@Test
 	fun `actualizar el saludo a un valor ok actualiza correctamente`() {
 		val nuevoSaludoDefault = "Hola San Martín!"
-		mockMvc.perform(put("/saludoDefault").content(nuevoSaludoDefault))
+		mockMvc.perform(plainTextPut("/saludoDefault").content(nuevoSaludoDefault))
 			.andExpect(status().isOk)
 		mockMvc.perform(get("/saludoDefault"))
 			.andExpect(status().isOk)
@@ -55,7 +58,7 @@ class SaludoApplicationTests(@Autowired val mockMvc: MockMvc) {
 
 	@AfterEach
 	fun `volvemos a dejar el saludo por defecto como estaba`() {
-		mockMvc.perform(put("/saludoDefault").content("Hola mundo!"))
+		mockMvc.perform(plainTextPut("/saludoDefault").content("Hola mundo!"))
 			.andExpect(status().isOk)
 	}
 }


### PR DESCRIPTION
* Springdoc-openapi se actualiza de 1.6.14 -> 2.2.0 para dar soporte a Spring Boot 3. Parte de la actualización mayor es un cambio en el nombre de dependencias.
* Se elimino una dependencia duplicada de jackson-module-kotlin, y se actualizó jackson-datatype-jsr310 a 2.15.2 como usa la versión de SpringBoot en el proyecto.

---

* En cuanto al endpoint, se agregó info explicita sobre mediatype al método "actualizarSaludoPersonalizado"
  - Sin aclararlo, openapi presume que va a enviarse un json para el objeto de entrada y salida (incluso si es un string). Esto provoca "errores" en la devolución sobre un JSON malformado, y que requiera insertar el nuevo saludo como un string entre comillas.
  - Como bonus se puede explicar mas funcionalidad de las etiquetas @xyzMapping




